### PR TITLE
Point to the pyBER repo in readme

### DIFF
--- a/doc/pages/PyBER.md
+++ b/doc/pages/PyBER.md
@@ -14,7 +14,7 @@ Next, install the required dependencies to run **PyBER**:
 
 ## Run PyBER
 
-From the `plotter/PyBER/` directory: 
+From the https://github.com/aff3ct/PyBER repo root directory: 
 
 	$ python3 pyBER.py
 


### PR DESCRIPTION
Simple change to PyBER readme to point to the new PyBer location.