### PR TITLE
Fix --chn-blk-fad channel parameter example in the docs

### DIFF
--- a/doc/source/user/simulation/parameters/channel/channel.rst
+++ b/doc/source/user/simulation/parameters/channel/channel.rst
@@ -248,8 +248,8 @@ experiments is an *Intel(R) Xeon(R) CPU E3-1270 v5 @ 3.60GHz* 8 threads |CPU|.
 
    :Type: text
    :Allowed values: ``NO`` ``FRAME`` ``ONETAP``
-   :Default: 1
-   :Examples: ``--chn-gain-occur 10``
+   :Default: ``NO``
+   :Examples: ``--chn-blk-fad NO``
 
 |factory::Channel::p+blk-fad|
 


### PR DESCRIPTION
Parameter example and default value were the same as --chn-gain-occur, so I modified the "Default", and "Example" values. I assumed that the value for the default field was "NO" after reading the note about FRAME and ONETAP not being implemented at the moment.