### PR TITLE
Removed const from puncture and depuncture signatures to resolve "passi…

### DIFF
--- a/include/Module/Puncturer/Puncturer.hpp
+++ b/include/Module/Puncturer/Puncturer.hpp
@@ -82,9 +82,9 @@ public:
 	 */
 	template <class A = std::allocator<B>>
 	void puncture(const std::vector<B,A>& X_N1, std::vector<B,A>& X_N2, const int frame_id = -1,
-	              const bool managed_memory = true) const;
+	              const bool managed_memory = true);
 
-	void puncture(const B *X_N1, B *X_N2, const int frame_id = -1, const bool managed_memory = true) const;
+	void puncture(const B *X_N1, B *X_N2, const int frame_id = -1, const bool managed_memory = true);
 
 	/*!
 	 * \brief Depunctures a codeword.
@@ -94,9 +94,9 @@ public:
 	 */
 	template <class A = std::allocator<Q>>
 	void depuncture(const std::vector<Q,A>& Y_N1, std::vector<Q,A>& Y_N2, const int frame_id = -1,
-	                const bool managed_memory = true) const;
+	                const bool managed_memory = true);
 
-	void depuncture(const Q *Y_N1, Q *Y_N2, const int frame_id = -1, const bool managed_memory = true) const;
+	void depuncture(const Q *Y_N1, Q *Y_N2, const int frame_id = -1, const bool managed_memory = true);
 
 protected:
 	virtual void _puncture(const B *X_N1, B *X_N2, const size_t frame_id) const;

--- a/include/Module/Puncturer/Puncturer.hxx
+++ b/include/Module/Puncturer/Puncturer.hxx
@@ -134,7 +134,7 @@ int Puncturer<B,Q>
 template <typename B, typename Q>
 template <class A>
 void Puncturer<B,Q>
-::puncture(const std::vector<B,A>& X_N1, std::vector<B,A>& X_N2, const int frame_id, const bool managed_memory) const
+::puncture(const std::vector<B,A>& X_N1, std::vector<B,A>& X_N2, const int frame_id, const bool managed_memory)
 {
 	(*this)[pct::sck::puncture::X_N1].bind(X_N1);
 	(*this)[pct::sck::puncture::X_N2].bind(X_N2);
@@ -143,7 +143,7 @@ void Puncturer<B,Q>
 
 template <typename B, typename Q>
 void Puncturer<B,Q>
-::puncture(const B *X_N1, B *X_N2, const int frame_id, const bool managed_memory) const
+::puncture(const B *X_N1, B *X_N2, const int frame_id, const bool managed_memory)
 {
 	(*this)[pct::sck::puncture::X_N1].bind(X_N1);
 	(*this)[pct::sck::puncture::X_N2].bind(X_N2);
@@ -153,7 +153,7 @@ void Puncturer<B,Q>
 template <typename B, typename Q>
 template <class A>
 void Puncturer<B,Q>
-::depuncture(const std::vector<Q,A>& Y_N1, std::vector<Q,A>& Y_N2, const int frame_id, const bool managed_memory) const
+::depuncture(const std::vector<Q,A>& Y_N1, std::vector<Q,A>& Y_N2, const int frame_id, const bool managed_memory)
 {
 	(*this)[pct::sck::depuncture::Y_N1].bind(Y_N1);
 	(*this)[pct::sck::depuncture::Y_N2].bind(Y_N2);
@@ -162,7 +162,7 @@ void Puncturer<B,Q>
 
 template <typename B, typename Q>
 void Puncturer<B,Q>
-::depuncture(const Q *Y_N1, Q *Y_N2, const int frame_id, const bool managed_memory) const
+::depuncture(const Q *Y_N1, Q *Y_N2, const int frame_id, const bool managed_memory)
 {
 	(*this)[pct::sck::depuncture::Y_N1].bind(Y_N1);
 	(*this)[pct::sck::depuncture::Y_N2].bind(Y_N2);


### PR DESCRIPTION
…ng ‘const aff3ct::module::Puncturer<int, float>’ as ‘this’ argument discards qualifiers [-fpermissive]" compile errors.

	modified:   include/Module/Puncturer/Puncturer.hpp
	modified:   include/Module/Puncturer/Puncturer.hxx