### PR TITLE
Updated DVB-RCS2 parameters for Turbo DB Puncturer and Interleaver

### DIFF
--- a/src/Module/Puncturer/Turbo_DB/Puncturer_turbo_DB.cpp
+++ b/src/Module/Puncturer/Turbo_DB/Puncturer_turbo_DB.cpp
@@ -19,19 +19,40 @@ Puncturer_turbo_DB<B,Q>
 
 	float rate = (float)K / (float)N;
 
-	     if (std::round(100.0 * rate) == std::round(100 * 2.0 / 5.0)) coderate = "2/5";
-	else if (std::round(100.0 * rate) == std::round(100 * 1.0 / 3.0)) coderate = "1/3";
-	else if (std::round(100.0 * rate) == std::round(100 * 1.0 / 2.0)) coderate = "1/2";
-	else if (std::round(100.0 * rate) == std::round(100 * 2.0 / 3.0)) coderate = "2/3";
-	else if (std::round(100.0 * rate) == std::round(100 * 3.0 / 4.0)) coderate = "3/4";
-	else if (std::round(100.0 * rate) == std::round(100 * 4.0 / 5.0)) coderate = "4/5";
-	else if (std::round(100.0 * rate) == std::round(100 * 5.0 / 6.0)) coderate = "5/6";
-	else
+	switch (int(rate * 100)) 
 	{
-		std::stringstream message;
-		message << "Unsupported code rate 'R' = 'K' / 'N' ('R' = " << rate << ", 'K' = " << K << ", 'N' = "
-		        << N << "), supported code rates are 2/5, 1/2, 2/3, 3/4, 4/5 and 5/6.";
-		throw tools::invalid_argument(__FILE__, __LINE__, __func__, message.str());
+		case 100 * 1 / 3:
+			coderate = "1/3";
+			break;
+		case 100 * 2 / 5:
+			coderate = "2/5";
+			break;
+		case 100 * 1 / 2:
+			coderate = "1/2";
+			break;
+		case 100 * 2 / 3:
+			coderate = "2/3";
+			break;
+		case 100 * 3 / 4:
+			coderate = "3/4";
+			break;
+		case 100 * 4 / 5:
+			coderate = "4/5";
+			break;
+		case 100 * 5 / 6:
+			coderate = "5/6";
+			break;
+		case 100 * 6 / 7:
+			coderate = "6/7";
+			break;
+		case 100 * 7 / 8:
+			coderate = "7/8";
+			break;
+		default:
+			std::stringstream message;
+			message << "Unsupported code rate 'R' = 'K' / 'N' ('R' = " << rate << ", 'K' = " << K << ", 'N' = "
+					<< N << "), supported code rates are 1/3, 2/5, 1/2, 2/3, 3/4, 4/5, 5/6, 6/7 and 7/8.";
+			throw tools::invalid_argument(__FILE__, __LINE__, __func__, message.str());
 	}
 }
 
@@ -48,39 +69,39 @@ template <typename B, typename Q>
 void Puncturer_turbo_DB<B,Q>
 ::_puncture(const B *X_N1, B *X_N2, const size_t frame_id) const
 {
-	if (coderate == "1/2")// all the AB, all the Y1Y2
+	if (coderate == "1/3")	// Pattern: [1] [1]
+	{
+		std::copy(X_N1, X_N1 + this->N_cw, X_N2);
+	}
+	else if (coderate == "2/5") // Pattern: [11] [10]
 	{
 		std::copy(X_N1, X_N1 + 2 * this->K, X_N2);
-	}
-	else if (coderate == "1/3")// all the AB, all the Y1Y2, all the W1W2
-	{
-		std::copy(X_N1, X_N1 + 3 * this->K, X_N2);
-	}
-	else if (coderate == "2/5")// all the AB, all the Y1Y2 , one W1W2 over two
-	{
-		std::copy(X_N1, X_N1 + 2 * this->K, X_N2);
-		auto j =  2 * this->K;
-		for(auto i = 0; i < this->K; i+=4)
+		auto j = 2 * this->K;
+		for(auto i = 0; i < this->K; i += 4)
 		{
 			X_N2[j++] = X_N1[2 * this->K + i    ];
 			X_N2[j++] = X_N1[2 * this->K + i + 1];
 		}
 	}
-	else if (coderate == "2/3") // all the AB, one Y1Y2 over two
+	else if (coderate == "1/2")	// Pattern: [1] [0]
+	{
+		std::copy(X_N1, X_N1 + 2 * this->K, X_N2);
+	}
+	else if (coderate == "2/3")	// Pattern: [10] [0]
 	{
 		std::copy(X_N1, X_N1 + this->K, X_N2);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=4)
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 4)
 		{
 			X_N2[j++] = X_N1[this->K + i    ];
 			X_N2[j++] = X_N1[this->K + i + 1];
 		}
 	}
-	else if (coderate == "3/4") // all the AB, two Y1Y2 over six : [101000]
+	else if (coderate == "3/4")	// Pattern: [101000] [0]
 	{
 		std::copy(X_N1, X_N1 + this->K, X_N2);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=12)
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 12)
 		{
 			X_N2[j++] = X_N1[this->K + i    ];
 			X_N2[j++] = X_N1[this->K + i + 1];
@@ -88,30 +109,58 @@ void Puncturer_turbo_DB<B,Q>
 			X_N2[j++] = X_N1[this->K + i + 5];
 		}
 	}
-	else if (coderate == "4/5") // all the AB, one Y1Y2 over four
+	else if (coderate == "4/5")	// Pattern: [1000] [0]
 	{
 		std::copy(X_N1, X_N1 + this->K, X_N2);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=8)
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 8)
 		{
 			X_N2[j++] = X_N1[this->K + i    ];
 			X_N2[j++] = X_N1[this->K + i + 1];
 		}
 	}
-	else if (coderate == "5/6") // all the AB, four Y1Y2 over twenty : [10001000100010000000]
+	else if (coderate == "5/6") // Pattern: [10001000100010000000] [0]
 	{
 		std::copy(X_N1, X_N1 + this->K, X_N2);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=40)
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 40)
+		{
+			X_N2[j++] = X_N1[this->K + i     ];
+			X_N2[j++] = X_N1[this->K + i + 1 ];
+			X_N2[j++] = X_N1[this->K + i + 8 ];
+			X_N2[j++] = X_N1[this->K + i + 9 ];
+			X_N2[j++] = X_N1[this->K + i + 16];
+			X_N2[j++] = X_N1[this->K + i + 17];
+			X_N2[j++] = X_N1[this->K + i + 24];
+			X_N2[j++] = X_N1[this->K + i + 25];
+		}
+	}
+	else if (coderate == "6/7") // Pattern: [100010000000] [0]
+	{
+		std::copy(X_N1, X_N1 + this->K, X_N2);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 24)
 		{
 			X_N2[j++] = X_N1[this->K + i    ];
 			X_N2[j++] = X_N1[this->K + i + 1];
 			X_N2[j++] = X_N1[this->K + i + 8];
 			X_N2[j++] = X_N1[this->K + i + 9];
-			X_N2[j++] = X_N1[this->K + i + 16];
-			X_N2[j++] = X_N1[this->K + i + 17];
+		}
+	}
+	else if (coderate == "7/8") // Pattern: [1000100000001000000010000000] [0]
+	{
+		std::copy(X_N1, X_N1 + this->K, X_N2);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 56)
+		{
+			X_N2[j++] = X_N1[this->K + i     ];
+			X_N2[j++] = X_N1[this->K + i + 1 ];
+			X_N2[j++] = X_N1[this->K + i + 8 ];
+			X_N2[j++] = X_N1[this->K + i + 9 ];
 			X_N2[j++] = X_N1[this->K + i + 24];
 			X_N2[j++] = X_N1[this->K + i + 25];
+			X_N2[j++] = X_N1[this->K + i + 40];
+			X_N2[j++] = X_N1[this->K + i + 41];
 		}
 	}
 }
@@ -120,43 +169,43 @@ template <typename B, typename Q>
 void Puncturer_turbo_DB<B,Q>
 ::_depuncture(const Q *Y_N1, Q *Y_N2, const size_t frame_id) const
 {
-	if (coderate == "1/2") // all the AB, all the Y1Y2
+	if (coderate == "1/3")	// Pattern: [1] [1]
 	{
-		std::copy(Y_N1              , Y_N1 + 2 * this->K, Y_N2);
-		std::fill(Y_N2 + 2 * this->K, Y_N2 + 3 * this->K, (Q)0);
+		std::copy(Y_N1, Y_N1 + this->N_cw, Y_N2);
 	}
-	else if (coderate == "1/3") // all the AB, all the Y1Y2, all the W1W2
+	else if (coderate == "2/5") // Pattern: [11] [10]
 	{
-		std::copy(Y_N1              , Y_N1 + 3 * this->K, Y_N2);
-	}
-	else if (coderate == "2/5")// all the AB, all the Y1Y2 , one W1W2 over two
-	{
-		std::copy(Y_N1              , Y_N1 + 2 * this->K, Y_N2);
-		std::fill(Y_N2 + 2 * this->K, Y_N2 + 3 * this->K, (Q)0);
-		auto j =  2 * this->K;
-		for(auto i = 0; i < this->K; i+=4)
+		std::copy(Y_N1, Y_N1 + 2 * this->K, Y_N2);
+		std::fill(Y_N2 + 2 * this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = 2 * this->K;
+		for(auto i = 0; i < this->K; i += 4)
 		{
 			Y_N2[2 * this->K + i    ] = Y_N1[j++];
 			Y_N2[2 * this->K + i + 1] = Y_N1[j++];
 		}
 	}
-	else if (coderate == "2/3") // all the AB, one Y1Y2 over two
+	else if (coderate == "1/2")	// Pattern: [1] [0]
 	{
-		std::copy(Y_N1          , Y_N1 +     this->K, Y_N2);
-		std::fill(Y_N2 + this->K, Y_N2 + 3 * this->K, (Q)0);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=4)
+		std::copy(Y_N1, Y_N1 + 2 * this->K, Y_N2);
+		std::fill(Y_N2 + 2 * this->K, Y_N2 + this->N_cw, (Q)0);
+	}
+	else if (coderate == "2/3")	// Pattern: [10] [0]
+	{
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 4)
 		{
 			Y_N2[this->K + i    ] = Y_N1[j++];
 			Y_N2[this->K + i + 1] = Y_N1[j++];
 		}
 	}
-	else if (coderate == "3/4") // all the AB, two Y1Y2 over six : [101000]
+	else if (coderate == "3/4")	// Pattern: [101000] [0]
 	{
-		std::copy(Y_N1          , Y_N1 +     this->K, Y_N2);
-		std::fill(Y_N2 + this->K, Y_N2 + 3 * this->K, (Q)0);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=12)
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 12)
 		{
 			Y_N2[this->K + i    ] = Y_N1[j++];
 			Y_N2[this->K + i + 1] = Y_N1[j++];
@@ -164,32 +213,62 @@ void Puncturer_turbo_DB<B,Q>
 			Y_N2[this->K + i + 5] = Y_N1[j++];
 		}
 	}
-	else if (coderate == "4/5") // all the AB, one Y1Y2 over four
+	else if (coderate == "4/5")	// Pattern: [1000] [0]
 	{
-		std::copy(Y_N1          , Y_N1 +     this->K, Y_N2);
-		std::fill(Y_N2 + this->K, Y_N2 + 3 * this->K, (Q)0);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=8)
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 8)
 		{
 			Y_N2[this->K + i    ] = Y_N1[j++];
 			Y_N2[this->K + i + 1] = Y_N1[j++];
 		}
 	}
-	else if (coderate == "5/6") // all the AB, four Y1Y2 over twenty : [10001000100010000000]
+	else if (coderate == "5/6") // Pattern: [10001000100010000000] [0]
 	{
-		std::copy(Y_N1          , Y_N1 +     this->K, Y_N2);
-		std::fill(Y_N2 + this->K, Y_N2 + 3 * this->K, (Q)0);
-		auto j =  this->K;
-		for(auto i = 0; i < this->K; i+=40)
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 40)
+		{
+			Y_N2[this->K + i     ] = Y_N1[j++];
+			Y_N2[this->K + i + 1 ] = Y_N1[j++];
+			Y_N2[this->K + i + 8 ] = Y_N1[j++];
+			Y_N2[this->K + i + 9 ] = Y_N1[j++];
+			Y_N2[this->K + i + 16] = Y_N1[j++];
+			Y_N2[this->K + i + 17] = Y_N1[j++];
+			Y_N2[this->K + i + 24] = Y_N1[j++];
+			Y_N2[this->K + i + 25] = Y_N1[j++];
+		}
+	}
+	else if (coderate == "6/7") // Pattern: [100010000000] [0]
+	{
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 24)
 		{
 			Y_N2[this->K + i    ] = Y_N1[j++];
 			Y_N2[this->K + i + 1] = Y_N1[j++];
 			Y_N2[this->K + i + 8] = Y_N1[j++];
 			Y_N2[this->K + i + 9] = Y_N1[j++];
-			Y_N2[this->K + i + 16] = Y_N1[j++];
-			Y_N2[this->K + i + 17] = Y_N1[j++];
+		}
+	}
+	else if (coderate == "7/8") // Pattern: [1000100000001000000010000000] [0]
+	{
+		std::copy(Y_N1, Y_N1 + this->K, Y_N2);
+		std::fill(Y_N2 + this->K, Y_N2 + this->N_cw, (Q)0);
+		auto j = this->K;
+		for(auto i = 0; i < this->K; i += 56)
+		{
+			Y_N2[this->K + i     ] = Y_N1[j++];
+			Y_N2[this->K + i + 1 ] = Y_N1[j++];
+			Y_N2[this->K + i + 8 ] = Y_N1[j++];
+			Y_N2[this->K + i + 9 ] = Y_N1[j++];
 			Y_N2[this->K + i + 24] = Y_N1[j++];
 			Y_N2[this->K + i + 25] = Y_N1[j++];
+			Y_N2[this->K + i + 40] = Y_N1[j++];
+			Y_N2[this->K + i + 41] = Y_N1[j++];
 		}
 	}
 }

--- a/src/Tools/Interleaver/ARP/Interleaver_core_ARP_DVB_RCS2.cpp
+++ b/src/Tools/Interleaver/ARP/Interleaver_core_ARP_DVB_RCS2.cpp
@@ -13,201 +13,267 @@ Interleaver_core_ARP_DVB_RCS2<T>
 {
 	switch (size)
 	{
-		case 56: // wfm 2
-			p  = 9;
-			q0 = 2;
-			q1 = 2;
-			q2 = 8;
-			q3 = 0;
-			break;
-		case 64:
-			p  = 19;
-			q0 = 1;
-			q1 = 3;
-			q2 = 8;
-			q3 = 1;
-			break;
-		case 152: // wfm 1, wfm 3
-			p  = 17;
-			q0 = 9;
-			q1 = 5;
-			q2 = 14;
-			q3 = 1;
-			break;
-		case 204:
-			p  = 23;
-			q0 = 10;
-			q1 = 5;
-			q2 = 0;
-			q3 = 0;
-			break;
-		case 228:
-			p  = 23;
-			q0 = 1;
-			q1 = 11;
-			q2 = 2;
-			q3 = 3;
-			break;
-		case 236:
-			p  = 23;
-			q0 = 10;
-			q1 = 2;
-			q2 = 11;
-			q3 = 1;
-			break;
-		case 340:
-			p  = 23;
-			q0 = 6;
-			q1 = 13;
-			q2 = 10;
-			q3 = 0;
-			break;
-		case 384:
-			p  = 23;
-			q0 = 6;
-			q1 = 13;
-			q2 = 10;
-			q3 = 0;
-			break;
-		case 400:
-			p  = 23;
-			q0 = 10;
-			q1 = 8;
-			q2 = 2;
-			q3 = 1;
-			break;
-		case 432:
-			p  = 29;
-			q0 = 1;
-			q1 = 4;
-			q2 = 1;
-			q3 = 1;
-			break;
-		case 440:
-			p  = 49;
-			q0 = 1;
-			q1 = 9;
-			q2 = 8;
-			q3 = 1;
-			break;
-		case 460: // wfm 8
-			p  = 29;
-			q0 = 6;
-			q1 = 5;
-			q2 = 0;
-			q3 = 0;
-			break;
-		case 492: // wfm 13
-			p  = 31;
-			q0 = 0;
-			q1 = 3;
-			q2 = 1;
-			q3 = 0;
-			break;
-		case 520: // wfm 9
-			p  = 31;
-			q0 = 0;
-			q1 = 1;
-			q2 = 2;
-			q3 = 0;
-			break;
-		case 576: // wfm 10
-			p  = 31;
-			q0 = 0;
-			q1 = 0;
-			q2 = 0;
-			q3 = 0;
-			break;
-		case 652:
-			p  = 107;
-			q0 = 2;
-			q1 = 10;
-			q2 = 15;
-			q3 = 1;
-			break;
-		case 680:
-			p  = 33;
-			q0 = 9;
-			q1 = 15;
-			q2 = 3;
-			q3 = 1;
-			break;
-		case 752:
-			p  = 37;
-			q0 = 1;
-			q1 = 3;
-			q2 = 4;
-			q3 = 2;
-			break;
-		case 864:
-			p  = 67;
-			q0 = 2;
-			q1 = 4;
-			q2 = 13;
-			q3 = 5;
-			break;
-		case 1056: // wfm 15
-			p  = 43;
-			q0 = 0;
-			q1 = 0;
-			q2 = 6;
-			q3 = 2;
-			break;
-		case 1192:
-			p  = 49;
-			q0 = 0;
-			q1 = 3;
-			q2 = 5;
-			q3 = 0;
-			break;
-		case 1332:
-			p  = 53;
-			q0 = 1;
-			q1 = 4;
-			q2 = 6;
-			q3 = 2;
-			break;
-		case 1420:
-			p  = 53;
-			q0 = 1;
-			q1 = 4;
-			q2 = 6;
-			q3 = 2;
-			break;
-		case 1504:
-			p  = 53;
-			q0 = 2;
-			q1 = 1;
-			q2 = 2;
-			q3 = 2;
-			break;
-		case 1600:
-			p  = 53;
-			q0 = 1;
-			q1 = 10;
-			q2 = 7;
-			q3 = 1;
-			break;
-		case 1752:
-			p  = 59;
-			q0 = 1;
-			q1 = 1;
-			q2 = 2;
-			q3 = 1;
-			break;
-		case 1777:
-			p  = 59;
-			q0 = 3;
-			q1 = 8;
-			q2 = 5;
-			q3 = 1;
-			break;
-		default:
-			std::stringstream message;
-			message << "There is no ARP parameters for 'size' = " << size << " (supported sizes are 56, 64, 152, "
-			        << "204, 228, 340, 384, 400, 432, 440, 652, 680, 752, 864, 1192, 1332, 1504 and 1752).";
-			throw runtime_error(__FILE__, __LINE__, __func__, message.str());
-			break;
+	// ======== // DVB-RCS2 Reference Waveforms (ETSI EN 301 545-2 V1.3.1 (2020-07), Annex A, Table A-1):
+	case 152:	// wfm 1, wfm 3
+		p  = 17;
+		q0 = 9;
+		q1 = 5;
+		q2 = 14;
+		q3 = 1;
+		break;
+	case 56:	// wfm 2
+		p  = 9;
+		q0 = 2;
+		q1 = 2;
+		q2 = 8;
+		q3 = 0;
+		break;
+	case 236:	// wfm 4, wfm 40, wfm 41
+		p  = 23;
+		q0 = 10;
+		q1 = 2;
+		q2 = 11;
+		q3 = 1;
+		break;
+	case 340:	// wfm 5
+		p  = 23;
+		q0 = 6;
+		q1 = 13;
+		q2 = 10;
+		q3 = 0;
+		break;
+	case 384:	// wfm 6
+		p  = 25;
+		q0 = 1;
+		q1 = 2;
+		q2 = 0;
+		q3 = 1;
+		break;
+	case 432:	// wfm 7
+		p  = 29;
+		q0 = 1;
+		q1 = 4;
+		q2 = 1;
+		q3 = 1;
+		break;
+	case 460:	// wfm 8
+		p  = 29;
+		q0 = 6;
+		q1 = 5;
+		q2 = 0;
+		q3 = 0;
+		break;
+	case 520:	// wfm 9
+		p  = 31;
+		q0 = 0;
+		q1 = 1;
+		q2 = 2;
+		q3 = 0;
+		break;
+	case 576:	// wfm 10
+		p  = 31;
+		q0 = 0;
+		q1 = 0;
+		q2 = 0;
+		q3 = 0;
+		break;
+	case 700:	// wfm 11
+		p  = 37;
+		q0 = 0;
+		q1 = 2;
+		q2 = 0;
+		q3 = 2;
+		break;
+	case 776:	// wfm 12
+		p  = 39;
+		q0 = 7;
+		q1 = 0;
+		q2 = 0;
+		q3 = 0;
+		break;
+	case 492:	// wfm 13, wfm 42
+		p  = 31;
+		q0 = 0;
+		q1 = 3;
+		q2 = 1;
+		q3 = 0;
+		break;
+	case 752:	// wfm 14, wfm 43
+		p  = 37;
+		q0 = 1;
+		q1 = 3;
+		q2 = 4;
+		q3 = 2;
+		break;
+	case 1056:	// wfm 15
+		p  = 43;
+		q0 = 0;
+		q1 = 0;
+		q2 = 6;
+		q3 = 2;
+		break;
+	case 1192:	// wfm 16
+		p  = 49;
+		q0 = 0;
+		q1 = 3;
+		q2 = 5;
+		q3 = 0;
+		break;
+	case 1332:	// wfm 17
+		p  = 49;
+		q0 = 0;
+		q1 = 5;
+		q2 = 0;
+		q3 = 5;
+		break;
+	case 1420:	// wfm 18
+		p  = 53;
+		q0 = 1;
+		q1 = 4;
+		q2 = 6;
+		q3 = 2;
+		break;
+	case 1600:	// wfm 19
+		p  = 53;
+		q0 = 1;
+		q1 = 10;
+		q2 = 7;
+		q3 = 1;
+		break;
+	case 1776:	// wfm 20
+		p  = 59;
+		q0 = 3;
+		q1 = 8;
+		q2 = 5;
+		q3 = 1;
+		break;
+	case 2156:	// wfm 21
+		p  = 65;
+		q0 = 0;
+		q1 = 3;
+		q2 = 7;
+		q3 = 0;
+		break;
+	case 2396:	// wfm 22
+		p  = 81;
+		q0 = 1;
+		q1 = 2;
+		q2 = 5;
+		q3 = 2;
+		break;
+	case 400:	// wfm 32, wfm 33
+		p  = 23;
+		q0 = 10;
+		q1 = 8;
+		q2 = 2;
+		q3 = 1;
+		break;
+	case 680:	// wfm 34, wfm 35, wfm 36
+		p  = 33;
+		q0 = 9;
+		q1 = 15;
+		q2 = 3;
+		q3 = 1;
+		break;
+	case 1752:	// wfm 37, wfm 38, wfm 39
+		p  = 59;
+		q0 = 1;
+		q1 = 1;
+		q2 = 2;
+		q3 = 1;
+		break;
+	case 204:	// wfm 44
+		p  = 23;
+		q0 = 10;
+		q1 = 5;
+		q2 = 0;
+		q3 = 0;
+		break;
+	case 220:	// wfm 45
+		p  = 23;
+		q0 = 6;
+		q1 = 10;
+		q2 = 4;
+		q3 = 0;
+		break;
+	case 248:	// wfm 46
+		p  = 23;
+		q0 = 6;
+		q1 = 8;
+		q2 = 1;
+		q3 = 1;
+		break;
+	case 276:	// wfm 47
+		p  = 25;
+		q0 = 1;
+		q1 = 1;
+		q2 = 2;
+		q3 = 0;
+		break;
+	case 336:	// wfm 48
+		p  = 23;
+		q0 = 8;
+		q1 = 1;
+		q2 = 4;
+		q3 = 1;
+		break;
+	case 372:	// wfm 49
+		p  = 25;
+		q0 = 1;
+		q1 = 7;
+		q2 = 2;
+		q3 = 1;
+		break;
+	// ======== // Old waveforms (source unknown), kept for compatibility:
+	case 64:
+		p  = 19;
+		q0 = 1;
+		q1 = 3;
+		q2 = 8;
+		q3 = 1;
+		break;
+	case 228:
+		p  = 23;
+		q0 = 1;
+		q1 = 11;
+		q2 = 2;
+		q3 = 3;
+		break;
+	case 440:
+		p  = 49;
+		q0 = 1;
+		q1 = 9;
+		q2 = 8;
+		q3 = 1;
+		break;
+	case 652:
+		p  = 107;
+		q0 = 2;
+		q1 = 10;
+		q2 = 15;
+		q3 = 1;
+		break;
+	case 864:
+		p  = 67;
+		q0 = 2;
+		q1 = 4;
+		q2 = 13;
+		q3 = 5;
+		break;
+	case 1504:
+		p  = 53;
+		q0 = 2;
+		q1 = 1;
+		q2 = 2;
+		q3 = 2;
+		break;
+	default:
+		std::stringstream message;
+		message << "There are no DVB-RCS2 parameters for 'size' = " << size << " (supported sizes are 56, 64, 152, "
+					"204, 220, 228, 236, 248, 276, 336, 340, 372, 384, 400, 432, 440, 460, 492, 520, 576, 652, 680, "
+					"700, 752, 776, 864, 1056, 1192, 1332, 1420, 1504, 1600, 1752, 1776, 2156 and 2396).";
+		throw runtime_error(__FILE__, __LINE__, __func__, message.str());
+		break;
 	}
 
 	this->init();


### PR DESCRIPTION
This PR adds several missing parameter sets and fixes some wrong ones for DVB-RCS2 modelling.

As I tried to simulate DVB-RCS2 Turbo FEC, I ran into a problem: not all of the reference waveforms from [EN 301 545-2](https://www.etsi.org/deliver/etsi_en/301500_301599/30154502/01.03.01_60/en_30154502v010301p.pdf#%5B%7B%22num%22%3A1360%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22FitH%22%7D%2C32%5D) were available in AFF3CT. Most notably, many DVB-RCS2 parameter sets were missing from the ARP Interleaver, and cases 384 and 1332 had wrong values assigned; also, case 1777 was supposed to be case 1776.

There were also two new code rates added (6/7 for wfm.39 and 7/8 for wfm.36) in the Turbo DB Puncturer.

There is a small issue, though: the puncturing pattern (100010000000) for code rate R=6/7 is correct for DVB-RCS2, but DVB-RCS1 has a different pattern (100000).