### PR TITLE
Decoder_RSC_BCJR_seq_scan: don't expose preprocessing defines.

### DIFF
--- a/include/Module/Decoder/RSC/BCJR/Seq/Decoder_RSC_BCJR_seq_scan.hxx
+++ b/include/Module/Decoder/RSC/BCJR/Seq/Decoder_RSC_BCJR_seq_scan.hxx
@@ -469,3 +469,6 @@ int Decoder_RSC_BCJR_seq_scan<B,R,RD>
 }
 }
 }
+
+#undef BLOCK
+#undef WINDOW


### PR DESCRIPTION
Don't expose such trivial defines (WINDOW, BLOCK) globally as they could clobber with user library or program own definitions.