### PR TITLE
Decoder_RSC_DB_BCJR_DVB_RCS1: don't import aff3ct::tools globally.

### DIFF
--- a/include/Module/Decoder/RSC_DB/BCJR/Decoder_RSC_DB_BCJR_DVB_RCS1.hxx
+++ b/include/Module/Decoder/RSC_DB/BCJR/Decoder_RSC_DB_BCJR_DVB_RCS1.hxx
@@ -4,8 +4,6 @@
 #include "Tools/Exception/exception.hpp"
 #include "Module/Decoder/RSC_DB/BCJR/Decoder_RSC_DB_BCJR_DVB_RCS1.hpp"
 
-using namespace aff3ct::tools;
-
 namespace aff3ct
 {
 namespace module


### PR DESCRIPTION
There is no point in importing everything from aff3ct::tools globally in this implementation file, is it? Compiles fine without. Probably stale hunk from previous merges?