### PR TITLE
transpose_selector: gracefully dispatch to all supported variants.

### DIFF
--- a/src/Tools/Perf/Transpose/transpose_selector.cpp
+++ b/src/Tools/Perf/Transpose/transpose_selector.cpp
@@ -2,9 +2,8 @@
 #include <cstdint>
 
 #include "Tools/Exception/exception.hpp"
-#ifdef __AVX2__
+#if defined(__i386__) || defined(__x86_64__)
 #include "Tools/Perf/Transpose/transpose_AVX.h"
-#elif defined(__SSE4_1__)
 #include "Tools/Perf/Transpose/transpose_SSE.h"
 #endif
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)
@@ -14,78 +13,80 @@
 
 bool aff3ct::tools::char_transpose(const signed char *src, signed char *dst, int n)
 {
-#if defined(__MIC__) || defined(__KNCNI__) || defined(__AVX512__) || defined(__AVX512F__)
-	int min_n = std::numeric_limits<int>::max();
-#elif defined(__AVX2__)
-	int min_n = 256;
-#elif defined(__SSE4_1__) || (defined(__ARM_NEON__) || defined(__ARM_NEON))
-	int min_n = 128;
-#else
-	int min_n = std::numeric_limits<int>::max();
-#endif
-
-	if (n >= min_n)
-	{
-#if defined(__MIC__) || defined(__KNCNI__) || defined(__AVX512__) || defined(__AVX512F__)
-		return false;
-#elif defined(__AVX2__)
+#if defined(__AVX2__)
+	do {
+		const int min_n = 256;
+		if (n < min_n)
+			break;
 		if (((uintptr_t)src) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'src' is unaligned memory.");
+			break;
 		if (((uintptr_t)dst) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'dst' is unaligned memory.");
+			break;
 		uchar_transpose_avx((__m256i*) src, (__m256i*) dst, n);
 		return true;
-#elif defined(__SSE4_1__)
+	} while (0);
+#endif
+#if defined(__SSE4_1__)
+	do {
+		const int min_n = 128;
+		if (n < min_n)
+			break;
 		if (((uintptr_t)src) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'src' is unaligned memory.");
+			break;
 		if (((uintptr_t)dst) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'dst' is unaligned memory.");
+			break;
 		uchar_transpose_sse((__m128i*) src, (__m128i*) dst, n);
 		return true;
-#elif (defined(__ARM_NEON__) || defined(__ARM_NEON))
+	} while (0);
+#endif
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON))
+	do {
+		const int min_n = 128;
+		if (n < min_n)
+			break;
 		uchar_transpose_neon((trans_TYPE*) src, (trans_TYPE*) dst, n);
 		return true;
+	} while (0);
 #endif
-	}
-
 	return false;
 }
 
 bool aff3ct::tools::char_itranspose(const signed char *src, signed char *dst, int n)
 {
-#if defined(__MIC__) || defined(__KNCNI__) || defined(__AVX512__) || defined(__AVX512F__)
-	int min_n = std::numeric_limits<int>::max();
-#elif defined(__AVX2__)
-	int min_n = 256;
-#elif defined(__SSE4_1__) || (defined(__ARM_NEON__) || defined(__ARM_NEON))
-	int min_n = 128;
-#else
-	int min_n = std::numeric_limits<int>::max();
-#endif
-
-	if (n >= min_n)
-	{
-#if defined(__MIC__) || defined(__KNCNI__) || defined(__AVX512__) || defined(__AVX512F__)
-		return false;
-#elif defined(__AVX2__)
+#if defined(__AVX2__)
+	do {
+		const int min_n = 256;
+		if (n < min_n)
+			break;
 		if (((uintptr_t)src) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'src' is unaligned memory.");
+			break;
 		if (((uintptr_t)dst) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'dst' is unaligned memory.");
+			break;
 		uchar_itranspose_avx((__m256i*) src, (__m256i*) dst, n / 8);
 		return true;
-#elif defined(__SSE4_1__)
+	} while (0);
+#endif
+#if defined(__SSE4_1__)
+	do {
+		const int min_n = 128;
+		if (n < min_n)
+			break;
 		if (((uintptr_t)src) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'src' is unaligned memory.");
+			break;
 		if (((uintptr_t)dst) % (min_n / 8))
-			throw runtime_error(__FILE__, __LINE__, __func__, "'dst' is unaligned memory.");
+			break;
 		uchar_itranspose_sse((__m128i*) src, (__m128i*) dst, n / 8);
 		return true;
-#elif (defined(__ARM_NEON__) || defined(__ARM_NEON))
+	} while (0);
+#endif
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON))
+	do {
+		const int min_n = 128;
+		if (n < min_n)
+			break;
 		uchar_itranspose_neon((trans_TYPE*) src, (trans_TYPE*) dst, n / 8);
 		return true;
+	} while (0);
 #endif
-	}
-
 	return false;
 }


### PR DESCRIPTION
Ensure correct selection flow for x86 SIMD variants, i.e. allow for AVX2 code path whenever possible, even on AVX512 systems ; allow for SSE4.1 code path whenever possible, even on AVX2 (and AVX512) systems.

Closes #182