### PR TITLE
CI: lower FER/BER is always OK for regression testing.

### DIFF
--- a/ci/test-regression.py
+++ b/ci/test-regression.py
@@ -127,7 +127,12 @@ class tableStats:
 			else:
 				pw = r[1]
 
-			diff = math.fabs(self.tableCur[i] - self.tableRef[i]) * 10**(-pw)
+			# consider lower error rates as always OK
+			diff = (self.tableCur[i] - self.tableRef[i]) * 10**(-pw)
+			if diff < 0 and (self.name in ("FER", "BER")):
+				diff = float(0)
+			else:
+				diff = math.fabs(diff)
 
 			if diff > self.sensibility:
 				self.errorsPos    .append(i)


### PR DESCRIPTION
Some AVX2 tests, and even SSE4 tests, randomly fail because the resulting error rates are lower than the reference. IMHO, lower error rates (BER, FER) should be accepted. Therefore, I am suggesting this patch to improve the PASS rate and accept lower BER/FER than reference.

Note: ignoring the lower error rates involve setting `diff` to zero. I am not quite sure of the expected behavior wrt. the sensibility computations. Otherwise, for `LDPC` tests, I need to set sensibility to 2.75 and weak rate to 0.87. Likewise, for `TURBO_PROD`tests, sensibility need to be increased to 2.75 too. Probably not a big deal in the end, but you get the idea. :)