### PR TITLE
Doc: fix build requirements.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,12 @@ mkdocs==1.5.3
 jinja2==3.0.0
 Sphinx==4.5.0
 sphinx-rtd-theme==1.3.0
+sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-bibtex==2.6.1
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.3
 sphinxcontrib-svg2pdfconverter==1.2.2
 breathe==4.35.0


### PR DESCRIPTION
Ensure suitable dependencies are installed for Sphinx v4.5. This implies downgrading some requirements that now depend on Sphinx >= v5.0.

This is a follows up for recent changes to the `development` branch. If I try to build the HTML documentation from a Python venv that was set up with `pip install -r requirements.txt`, I would end up into an error mentioning that some sphinxcontrib modules require Sphinx >= v5.0. I have no opinion on what the proper fix would be, I just picked the latest modules that were compatible with Sphinx v4.5.