### PR TITLE
added stream argument to print_paramters call

### DIFF
--- a/src/Tools/Factory/Header.cpp
+++ b/src/Tools/Factory/Header.cpp
@@ -26,7 +26,7 @@ aff3ct::tools::Header::print_parameters(std::string grp_key,
         stream << rang::tag::comment << "* " << rang::style::bold << rang::style::underline << grp_name
                << rang::style::reset << " ";
         for (auto i = 0; i < 46 - (int)grp_name.length(); i++)
-            std::cout << "-";
+            stream << "-";
         stream << std::endl;
     }
     else if (key.size() > 1)
@@ -34,7 +34,7 @@ aff3ct::tools::Header::print_parameters(std::string grp_key,
         stream << rang::tag::comment << "   " << rang::style::bold << rang::style::underline << grp_name
                << rang::style::reset << " ";
         for (auto i = 0; i < 45 - (int)grp_name.length(); i++)
-            std::cout << "-";
+            stream << "-";
         stream << std::endl;
     }
 

--- a/src/Tools/Factory/Header.cpp
+++ b/src/Tools/Factory/Header.cpp
@@ -111,7 +111,7 @@ aff3ct::tools::Header::print_parameters(const std::vector<factory::Factory*>& fa
                 if (print_head && (std::find(dup_h.begin(), dup_h.end(), h) == dup_h.end() ||
                                    std::find(dup_n.begin(), dup_n.end(), n) == dup_n.end()))
                 {
-                    aff3ct::tools::Header::print_parameters(prefixes[i], n, h, max_n_chars);
+                    aff3ct::tools::Header::print_parameters(prefixes[i], n, h, max_n_chars, stream);
 
                     dup_h.push_back(h);
                     dup_n.push_back(n);


### PR DESCRIPTION
> The print_parameters function that accepts a list of factories as an argument
> also accepts an ostream argument, stream. This stream argument is unused in
> the function body, with the result that parameters can only be printed to the
> default stream, std::cout. Adding 'stream' to the call of the overloaded
> print_parameters function resolves this.