### PR TITLE
Fix transform_H_to_G_identity for rank-deficient matrices

### DIFF
--- a/src/Tools/Code/LDPC/Matrix_handler/LDPC_matrix_handler.cpp
+++ b/src/Tools/Code/LDPC/Matrix_handler/LDPC_matrix_handler.cpp
@@ -489,11 +489,15 @@ LDPC_matrix_handler ::transform_H_to_G_identity(const LDPC_matrix& H, Positions_
     H.is_of_way_throw(Matrix::Way::HORIZONTAL);
     auto G = H;
 
-    auto M = H.get_n_rows();
     auto N = H.get_n_cols();
-    auto K = N - M;
 
     auto swapped_cols = LDPC_matrix_handler::form_diagonal(G, Matrix::Origin::TOP_LEFT);
+
+    // form_diagonal may delete zero rows from rank-deficient matrices,
+    // so use the post-elimination row count (= rank) instead of the original.
+    auto M = G.get_n_rows();
+    auto K = N - M;
+
     LDPC_matrix_handler::form_identity(G, Matrix::Origin::TOP_LEFT);
 
     // erase the just created M*M identity in the left part of H and add the K*K identity below


### PR DESCRIPTION
## Summary

- `transform_H_to_G_identity` computed `M` and `K` from the raw row count of `H` **before** calling `form_diagonal`, which deletes zero/redundant rows for rank-deficient matrices.
- For the IEEE 802.3an 10G-BASE-T LDPC code (H has 384 rows but rank 325), this produced `K = 2048 - 384 = 1664` instead of the correct `K = 2048 - 325 = 1723`.
- This fix moves `M` and `K` computation to **after** `form_diagonal`, using `G.get_n_rows()` (the actual rank) instead of `H.get_n_rows()`.

## Note
The CLI simulation is unaffected because it takes `K` as a command-line argument (`-K 1723`) and uses AZCW encoding, bypassing this code path entirely. However, any programmatic use of `transform_H_to_G_identity` with rank-deficient matrices would get the wrong `info_bits_pos`.

## Test plan

- [x] Verified with 10GBPS-ETHERNET_1723_2048.alist: K=1723 (was 1664 before fix)
- [x] Verified BER matches reference curves at Eb/N0 = 3.0, 3.5, 4.0 dB