### PR TITLE
Integrate feedforward convolutional code into the simulator

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -276,6 +276,7 @@ rst_epilog = """
 .. |CISC|      replace:: :abbr:`CISC     (Complex Instruction Set Computer)`
 .. |CN|        replace:: :abbr:`CN       (Check Node)`
 .. |CNs|       replace:: :abbr:`CNs      (Check Nodes)`
+.. |CONV|      replace:: :abbr:`CONV     (Convolutional)`
 .. |codec|     replace:: :abbr:`codec    (coder/decoder)`
 .. |codecs|    replace:: :abbr:`codecs   (coders/decodes)`
 .. |CP|        replace:: :abbr:`CP       (Chase-Pyndiah)`

--- a/doc/source/user/simulation/parameters/codec/codec.rst
+++ b/doc/source/user/simulation/parameters/codec/codec.rst
@@ -9,6 +9,7 @@ Codec parameters
 
    common/codec
    bch/codec
+   conv/codec
    ldpc/codec
    polar/codec
    polar_mk/codec

--- a/doc/source/user/simulation/parameters/codec/conv/codec.rst
+++ b/doc/source/user/simulation/parameters/codec/conv/codec.rst
@@ -1,0 +1,11 @@
+.. _codec-conv:
+
+Codec |CONV|
+************
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   encoder.rst
+   decoder.rst

--- a/doc/source/user/simulation/parameters/codec/conv/decoder.rst
+++ b/doc/source/user/simulation/parameters/codec/conv/decoder.rst
@@ -1,0 +1,63 @@
+.. _dec-conv-decoder-parameters:
+
+|CONV| Decoder parameters
+-------------------------
+
+.. _dec-conv-dec-type:
+
+``--dec-type, -D``
+""""""""""""""""""
+
+   :Type: text
+   :Allowed values: ``VITERBI`` ``PLVA`` ``CHASE`` ``ML``
+   :Default: ``VITERBI``
+   :Examples: ``--dec-type VITERBI``
+
+|factory::Decoder::p+type,D|
+
+Description of the allowed values:
+
++--------------+------------------------------------------------------------------+
+| Value        | Description                                                      |
++==============+==================================================================+
+| ``VITERBI``  | Select the Viterbi algorithm from :cite:`Viterbi1967`.           |
++--------------+------------------------------------------------------------------+
+| ``PLVA``     | Select the |PLVA| algorithm from :cite:`Seshadri1994`.           |
++--------------+------------------------------------------------------------------+
+| ``CHASE``    | See the common :ref:`dec-common-dec-type` parameter.             |
++--------------+------------------------------------------------------------------+
+| ``ML``       | See the common :ref:`dec-common-dec-type` parameter.             |
++--------------+------------------------------------------------------------------+
+
+.. note:: Only rate-1/2 feedforward convolutional codes are supported. The
+   |BCJR| algorithm is not available for this codec; for a soft-output decoder
+   use the :ref:`Codec RSC <codec-rsc>` instead.
+
+.. _dec-conv-dec-implem:
+
+``--dec-implem``
+""""""""""""""""
+
+   :Type: text
+   :Allowed values: ``STD``
+   :Default: ``STD``
+   :Examples: ``--dec-implem STD``
+
+|factory::Decoder::p+implem|
+
+.. _dec-conv-dec-lists:
+
+``--dec-lists, -L``
+"""""""""""""""""""
+
+   :Type: integer
+   :Default: ``8``
+   :Examples: ``--dec-lists 32``
+
+|factory::Decoder_conv::p+lists,L|
+
+References
+""""""""""
+
+.. bibliography:: references.bib
+   :labelprefix: Conv-

--- a/doc/source/user/simulation/parameters/codec/conv/encoder.rst
+++ b/doc/source/user/simulation/parameters/codec/conv/encoder.rst
@@ -1,0 +1,78 @@
+.. _enc-conv-encoder-parameters:
+
+|CONV| Encoder parameters
+-------------------------
+
+.. _enc-conv-enc-info-bits:
+
+``--enc-info-bits, -K`` |image_required_argument|
+"""""""""""""""""""""""""""""""""""""""""""""""""
+
+   :Type: integer
+   :Examples: ``--enc-info-bits 64``
+
+|factory::Encoder::p+info-bits,K|
+
+The codeword size :math:`N` is automatically deduced:
+:math:`N = 2 \times (K + \log_2(ts))` where :math:`ts` is the trellis size.
+
+.. _enc-conv-enc-type:
+
+``--enc-type``
+""""""""""""""
+
+   :Type: text
+   :Allowed values: ``CONV`` ``AZCW`` ``COSET`` ``USER``
+   :Default: ``CONV``
+   :Examples: ``--enc-type AZCW``
+
+|factory::Encoder::p+type|
+
+Description of the allowed values:
+
++-----------+------------------------+
+| Value     | Description            |
++===========+========================+
+| ``CONV``  | |enc-type_descr_conv|  |
++-----------+------------------------+
+| ``AZCW``  | |enc-type_descr_azcw|  |
++-----------+------------------------+
+| ``COSET`` | |enc-type_descr_coset| |
++-----------+------------------------+
+| ``USER``  | |enc-type_descr_user|  |
++-----------+------------------------+
+
+.. |enc-type_descr_conv| replace:: Select the standard feedforward
+   convolutional encoder.
+.. |enc-type_descr_azcw| replace:: See the common :ref:`enc-common-enc-type`
+   parameter.
+.. |enc-type_descr_coset| replace:: See the common :ref:`enc-common-enc-type`
+   parameter.
+.. |enc-type_descr_user| replace:: See the common :ref:`enc-common-enc-type`
+   parameter.
+
+Unlike the :ref:`Codec RSC <codec-rsc>`, the convolutional encoder is
+**feedforward** (non-recursive and non-systematic). The encoded output is
+interleaved: for :math:`K` information bits and :math:`n_{\mathit{ff}} =
+\log_2(ts)` memory elements, the encoder outputs
+:math:`X_0^{(0)}, X_0^{(1)}, X_1^{(0)}, X_1^{(1)}, [...], X_{K-1}^{(0)},
+X_{K-1}^{(1)}, X_{0}^{(0)^t}, X_{0}^{(1)^t}, [...],
+X_{n_{\mathit{ff}}-1}^{(0)^t}, X_{n_{\mathit{ff}}-1}^{(1)^t}`, where
+:math:`X^{(0)}` and :math:`X^{(1)}` are respectively the outputs of the first
+and second generator polynomial, and :math:`t` the *tail bits* used to drive
+the encoder back to the zero state.
+
+.. _enc-conv-enc-poly:
+
+``--enc-poly``
+""""""""""""""
+
+   :Type: text
+   :Default: ``"{0171,0133}"``
+   :Examples: ``--enc-poly "{023,033}"``
+
+|factory::Encoder_conv::p+poly|
+
+The default ``{0171,0133}`` corresponds to the industry-standard constraint
+length 7, rate 1/2 NASA code, also used as the inner code of the Galileo E1B
+signal.

--- a/doc/source/user/simulation/parameters/codec/conv/references.bib
+++ b/doc/source/user/simulation/parameters/codec/conv/references.bib
@@ -1,0 +1,23 @@
+@Article{Viterbi1967,
+  author   = {Viterbi, A.},
+  journal  = {IEEE Transactions on Information Theory},
+  title    = {Error Bounds for Convolutional Codes and an Asymptotically Optimum Decoding Algorithm},
+  year     = {1967},
+  volume   = {13},
+  number   = {2},
+  pages    = {260-269},
+  keywords = {},
+  doi      = {10.1109/TIT.1967.1054010},
+}
+
+@Article{Seshadri1994,
+  author   = {Seshadri, N. and Sundberg, C.-E.W.},
+  journal  = {IEEE Transactions on Communications},
+  title    = {List Viterbi Decoding Algorithms with Applications},
+  year     = {1994},
+  volume   = {42},
+  number   = {234},
+  pages    = {313-323},
+  keywords = {Viterbi algorithm;Iterative algorithms;AWGN;Iterative decoding;Convolutional codes;Concatenated codes;Performance analysis;Algorithm design and analysis;Analytical models;Additive white noise},
+  doi      = {10.1109/TCOMM.1994.577040},
+}

--- a/doc/source/user/simulation/parameters/simulation/simulation.rst
+++ b/doc/source/user/simulation/parameters/simulation/simulation.rst
@@ -55,9 +55,9 @@ Description of the allowed values:
 """"""""""""""""""""""""""""""""""""""""""""""""
 
    :Type: text
-   :Allowed values: ``BCH`` ``LDPC`` ``POLAR`` ``POLAR_MK`` ``POLAR_PAC``
-                    ``RA`` ``REP`` ``RS`` ``RSC`` ``RSC_DB`` ``TURBO``
-                    ``TURBO_DB`` ``TURBO_PROD`` ``UNCODED``
+   :Allowed values: ``BCH`` ``CONV`` ``LDPC`` ``POLAR`` ``POLAR_MK``
+                    ``POLAR_PAC`` ``RA`` ``REP`` ``RS`` ``RSC`` ``RSC_DB``
+                    ``TURBO`` ``TURBO_DB`` ``TURBO_PROD`` ``UNCODED``
    :Examples: ``-C BCH``
 
 |factory::Launcher::p+cde-type,C|
@@ -71,6 +71,7 @@ Description of the allowed values:
 .. _Repetition: https://en.wikipedia.org/wiki/Repetition_code
 .. _Reed-Solomon: https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction
 .. _Recursive Systematic Convolutional: https://en.wikipedia.org/wiki/Convolutional_code
+.. _Convolutional: https://en.wikipedia.org/wiki/Convolutional_code
 .. _Turbo: https://en.wikipedia.org/wiki/Turbo_code
 .. _Turbo Product: http://www.ieee802.org/16/tutorial/80216t-00_01.pdf
 
@@ -78,6 +79,8 @@ Description of the allowed values:
 | Value          | Description                                                 |
 +================+=============================================================+
 | ``BCH``        | The `Bose–Chaudhuri–Hocquenghem`_ codes :cite:`Bose1960`.   |
++----------------+-------------------------------------------------------------+
+| ``CONV``       | Feedforward `Convolutional`_ codes (rate 1/2).              |
 +----------------+-------------------------------------------------------------+
 | ``LDPC``       | The `Low-Density Parity-Check`_ codes                       |
 |                | :cite:`Gallager1963,MacKay1995a`.                           |

--- a/doc/strings.rst
+++ b/doc/strings.rst
@@ -381,6 +381,15 @@
    Set the correction power of the |RS| decoder. This value corresponds to the
    number of symbols errors that the decoder is able to correct.
 
+.. -------------------------------------------- factory Decoder_conv parameters
+
+.. |factory::Decoder_conv::p+poly| replace::
+   Set the polynomials describing the feedforward convolutional code, should
+   be of the form "{A,B}".
+
+.. |factory::Decoder_conv::p+lists,L| replace::
+   Set the number of lists to maintain in the |PLVA| decoder.
+
 .. --------------------------------------------- factory Decoder_RSC parameters
 
 .. |factory::Decoder_RSC::p+simd| replace::
@@ -539,6 +548,13 @@
    Define the convolutionnal code (ex.: "0o33").
 
 .. ---------------------------------------------- factory Encoder_RA parameters
+
+.. -------------------------------------------- factory Encoder_conv parameters
+
+.. |factory::Encoder_conv::p+poly| replace::
+   Set the polynomials that define the feedforward convolutional code (or the
+   trellis structure). The expected form is :math:`\{A,B\}` where :math:`A`
+   and :math:`B` are given in octal.
 
 .. -------------------------------------- factory Encoder_repetition parameters
 

--- a/include/Factory/Module/Decoder/Conv/Decoder_conv.hpp
+++ b/include/Factory/Module/Decoder/Conv/Decoder_conv.hpp
@@ -1,0 +1,60 @@
+/*!
+ * \file
+ * \brief Class factory::Decoder_conv.
+ */
+#ifndef FACTORY_DECODER_CONV_HPP
+#define FACTORY_DECODER_CONV_HPP
+
+#include <cli.hpp>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "Factory/Module/Decoder/Decoder.hpp"
+#include "Module/CRC/CRC.hpp"
+#include "Module/Decoder/Decoder_SIHO.hpp"
+#include "Module/Encoder/Encoder.hpp"
+#include "Tools/Factory/Header.hpp"
+
+namespace aff3ct
+{
+namespace factory
+{
+extern const std::string Decoder_conv_name;
+extern const std::string Decoder_conv_prefix;
+class Decoder_conv : public Decoder
+{
+  public:
+    // ----------------------------------------------------------------------------------------------------- PARAMETERS
+    // optional parameters
+    std::vector<int> poly = { 0171, 0133 };
+    unsigned int L = 8;
+
+    // -------------------------------------------------------------------------------------------------------- METHODS
+    explicit Decoder_conv(const std::string& p = Decoder_conv_prefix);
+    virtual ~Decoder_conv() = default;
+    Decoder_conv* clone() const;
+
+    // parameters construction
+    void get_description(cli::Argument_map_info& args) const;
+    void store(const cli::Argument_map_value& vals);
+    void get_headers(std::map<std::string, tools::header_list>& headers, const bool full = true) const;
+
+    // builder
+    template<typename B = int, typename Q = float>
+    module::Decoder_SIHO<B, Q>* build(const std::vector<std::vector<int>>& trellis,
+                                      const module::CRC<B>* crc = nullptr,
+                                      module::Encoder<B>* encoder = nullptr) const;
+
+    template<typename B = int, typename Q = float>
+    module::Decoder_SIHO<B, Q>* build_viterbi(const std::vector<std::vector<int>>& trellis) const;
+
+    template<typename B = int, typename Q = float>
+    module::Decoder_SIHO<B, Q>* build_viterbi_list(const std::vector<std::vector<int>>& trellis,
+                                                   const module::CRC<B>* crc) const;
+};
+}
+}
+
+#endif /* FACTORY_DECODER_CONV_HPP */

--- a/include/Factory/Module/Encoder/Conv/Encoder_conv.hpp
+++ b/include/Factory/Module/Encoder/Conv/Encoder_conv.hpp
@@ -1,0 +1,47 @@
+/*!
+ * \file
+ * \brief Class factory::Encoder_conv.
+ */
+#ifndef FACTORY_ENCODER_CONV_HPP
+#define FACTORY_ENCODER_CONV_HPP
+
+#include <cli.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "Factory/Module/Encoder/Encoder.hpp"
+#include "Module/Encoder/Conv/Encoder_conv.hpp"
+#include "Tools/Factory/Header.hpp"
+
+namespace aff3ct
+{
+namespace factory
+{
+extern const std::string Encoder_conv_name;
+extern const std::string Encoder_conv_prefix;
+class Encoder_conv : public Encoder
+{
+  public:
+    // ----------------------------------------------------------------------------------------------------- PARAMETERS
+    // optional
+    std::vector<int> poly = { 0171, 0133 };
+
+    // -------------------------------------------------------------------------------------------------------- METHODS
+    explicit Encoder_conv(const std::string& p = Encoder_conv_prefix);
+    virtual ~Encoder_conv() = default;
+    Encoder_conv* clone() const;
+
+    // parameters construction
+    void get_description(cli::Argument_map_info& args) const;
+    void store(const cli::Argument_map_value& vals);
+    void get_headers(std::map<std::string, tools::header_list>& headers, const bool full = true) const;
+
+    // builder
+    template<typename B = int>
+    module::Encoder_conv<B>* build() const;
+};
+}
+}
+
+#endif /* FACTORY_ENCODER_CONV_HPP */

--- a/include/Factory/Tools/Codec/Conv/Codec_conv.hpp
+++ b/include/Factory/Tools/Codec/Conv/Codec_conv.hpp
@@ -1,0 +1,42 @@
+/*!
+ * \file
+ * \brief Class factory::Codec_conv.
+ */
+#ifndef FACTORY_CODEC_CONV_HPP
+#define FACTORY_CODEC_CONV_HPP
+
+#include <cli.hpp>
+#include <map>
+#include <string>
+
+#include "Factory/Tools/Codec/Codec_SIHO.hpp"
+#include "Module/CRC/CRC.hpp"
+#include "Tools/Codec/Conv/Codec_conv.hpp"
+#include "Tools/Factory/Header.hpp"
+
+namespace aff3ct
+{
+namespace factory
+{
+extern const std::string Codec_conv_name;
+extern const std::string Codec_conv_prefix;
+class Codec_conv : public Codec_SIHO
+{
+  public:
+    explicit Codec_conv(const std::string& p = Codec_conv_prefix);
+    virtual ~Codec_conv() = default;
+    Codec_conv* clone() const;
+
+    // parameters construction
+    void get_description(cli::Argument_map_info& args) const;
+    void store(const cli::Argument_map_value& vals);
+    void get_headers(std::map<std::string, tools::header_list>& headers, const bool full = true) const;
+
+    // builder
+    template<typename B = int, typename Q = float>
+    tools::Codec_conv<B, Q>* build(const module::CRC<B>* crc = nullptr) const;
+};
+}
+}
+
+#endif /* FACTORY_CODEC_CONV_HPP */

--- a/include/Module/Encoder/Conv/Encoder_conv.hpp
+++ b/include/Module/Encoder/Conv/Encoder_conv.hpp
@@ -31,6 +31,8 @@ class Encoder_conv
     Encoder_conv(const int K, const int N, const std::vector<int>& poly);
     virtual ~Encoder_conv() = default;
 
+    virtual Encoder_conv<B>* clone() const;
+
     int tail_length() const override;
     std::vector<std::vector<int>> get_trellis() override;
 

--- a/include/Tools/Codec/Conv/Codec_conv.hpp
+++ b/include/Tools/Codec/Conv/Codec_conv.hpp
@@ -1,0 +1,39 @@
+/*!
+ * \file
+ * \brief Class tools::Codec_conv.
+ */
+#ifndef CODEC_CONV_HPP_
+#define CODEC_CONV_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "Factory/Module/Decoder/Conv/Decoder_conv.hpp"
+#include "Factory/Module/Encoder/Conv/Encoder_conv.hpp"
+#include "Module/CRC/CRC.hpp"
+#include "Tools/Codec/Codec_SIHO.hpp"
+
+namespace aff3ct
+{
+namespace tools
+{
+template<typename B = int, typename Q = float>
+class Codec_conv : public Codec_SIHO<B, Q>
+{
+  protected:
+    std::shared_ptr<std::vector<std::vector<int>>> trellis;
+
+  public:
+    Codec_conv(const factory::Encoder_conv& enc_params,
+               const factory::Decoder_conv& dec_params,
+               const module::CRC<B>* crc = nullptr);
+    virtual ~Codec_conv() = default;
+
+    virtual Codec_conv<B, Q>* clone() const;
+
+    const std::vector<std::vector<int>>& get_trellis() const;
+};
+}
+}
+
+#endif /* CODEC_CONV_HPP_ */

--- a/include/aff3ct.hpp
+++ b/include/aff3ct.hpp
@@ -24,6 +24,9 @@
 #ifndef FACTORY_DECODER_BCH_HPP
 #include <Factory/Module/Decoder/BCH/Decoder_BCH.hpp>
 #endif
+#ifndef FACTORY_DECODER_CONV_HPP
+#include <Factory/Module/Decoder/Conv/Decoder_conv.hpp>
+#endif
 #ifndef FACTORY_DECODER_HPP_
 #include <Factory/Module/Decoder/Decoder.hpp>
 #endif
@@ -68,6 +71,9 @@
 #endif
 #ifndef FACTORY_ENCODER_BCH_HPP
 #include <Factory/Module/Encoder/BCH/Encoder_BCH.hpp>
+#endif
+#ifndef FACTORY_ENCODER_CONV_HPP
+#include <Factory/Module/Encoder/Conv/Encoder_conv.hpp>
 #endif
 #ifndef FACTORY_ENCODER_HPP
 #include <Factory/Module/Encoder/Encoder.hpp>
@@ -155,6 +161,9 @@
 #endif
 #ifndef FACTORY_CODEC_BCH_HPP
 #include <Factory/Tools/Codec/BCH/Codec_BCH.hpp>
+#endif
+#ifndef FACTORY_CODEC_CONV_HPP
+#include <Factory/Tools/Codec/Conv/Codec_conv.hpp>
 #endif
 #ifndef FACTORY_CODEC_HIHO_HPP_
 #include <Factory/Tools/Codec/Codec_HIHO.hpp>

--- a/src/Factory/Launcher/Launcher.cpp
+++ b/src/Factory/Launcher/Launcher.cpp
@@ -10,6 +10,7 @@
 
 #include "Factory/Launcher/Launcher.hpp"
 #include "Launcher/Code/BCH/BCH.hpp"
+#include "Launcher/Code/Conv/Conv.hpp"
 #include "Launcher/Code/LDPC/LDPC.hpp"
 #include "Launcher/Code/Polar/Polar.hpp"
 #include "Launcher/Code/Polar_MK/Polar_MK.hpp"
@@ -73,6 +74,7 @@ Launcher ::get_description(cli::Argument_map_info& args) const
                                                 "RA",
                                                 "RSC",
                                                 "RSC_DB",
+                                                "CONV",
                                                 "BCH",
                                                 "UNCODED",
                                                 "RS")),
@@ -250,6 +252,11 @@ Launcher ::build(const int argc, const char** argv) const
     {
         if (this->sim_type == "BFER") return new launcher::RSC_DB<launcher::BFER_std<B, R, Q>, B, R, Q>(argc, argv);
         if (this->sim_type == "BFERI") return new launcher::RSC_DB<launcher::BFER_ite<B, R, Q>, B, R, Q>(argc, argv);
+    }
+
+    if (this->cde_type == "CONV")
+    {
+        if (this->sim_type == "BFER") return new launcher::Conv<launcher::BFER_std<B, R, Q>, B, R, Q>(argc, argv);
     }
 
     if (this->cde_type == "TURBO")

--- a/src/Factory/Module/Decoder/Conv/Decoder_conv.cpp
+++ b/src/Factory/Module/Decoder/Conv/Decoder_conv.cpp
@@ -1,0 +1,154 @@
+#include <cmath>
+#include <cstdio>
+#include <streampu.hpp>
+#include <utility>
+
+#include "Factory/Module/Decoder/Conv/Decoder_conv.hpp"
+#include "Module/Decoder/Conv/Viterbi/Decoder_Viterbi_SIHO.hpp"
+#include "Module/Decoder/Conv/Viterbi_list/Decoder_Viterbi_list_parallel.hpp"
+#include "Tools/Documentation/documentation.h"
+
+using namespace aff3ct;
+using namespace aff3ct::factory;
+
+const std::string aff3ct::factory::Decoder_conv_name = "Decoder CONV";
+const std::string aff3ct::factory::Decoder_conv_prefix = "dec";
+
+Decoder_conv ::Decoder_conv(const std::string& prefix)
+  : Decoder(Decoder_conv_name, prefix)
+{
+    this->type = "VITERBI";
+    this->implem = "STD";
+    this->systematic = false;
+}
+
+Decoder_conv*
+Decoder_conv ::clone() const
+{
+    return new Decoder_conv(*this);
+}
+
+void
+Decoder_conv ::get_description(cli::Argument_map_info& args) const
+{
+    Decoder::get_description(args);
+
+    auto p = this->get_prefix();
+    const std::string class_name = "factory::Decoder_conv::";
+
+    args.erase({ p + "-cw-size", "N" });
+
+    cli::add_options(args.at({ p + "-type", "D" }), 0, "VITERBI", "PLVA");
+    cli::add_options(args.at({ p + "-implem" }), 0, "STD");
+
+    tools::add_arg(args, p, class_name + "p+poly", cli::Text());
+
+    tools::add_arg(args, p, class_name + "p+lists,L", cli::Integer(cli::Positive(), cli::Non_zero()));
+}
+
+void
+Decoder_conv ::store(const cli::Argument_map_value& vals)
+{
+    Decoder::store(vals);
+
+    auto p = this->get_prefix();
+
+    if (vals.exist({ p + "-type", "D" })) this->type = vals.at({ p + "-type", "D" });
+    if (vals.exist({ p + "-lists", "L" })) this->L = vals.to_int({ p + "-lists", "L" });
+
+    if (vals.exist({ p + "-poly" }))
+    {
+        auto poly_str = vals.at({ p + "-poly" });
+
+#ifdef _MSC_VER
+        sscanf_s(poly_str.c_str(), "{%o,%o}", &this->poly[0], &this->poly[1]);
+#else
+        std::sscanf(poly_str.c_str(), "{%o,%o}", &this->poly[0], &this->poly[1]);
+#endif
+    }
+
+    const int n_ff = (int)std::floor(std::log2((float)std::max(this->poly[0], this->poly[1])));
+    this->tail_length = 2 * n_ff;
+    this->N_cw = 2 * this->K + this->tail_length;
+    this->R = (float)this->K / (float)this->N_cw;
+}
+
+void
+Decoder_conv ::get_headers(std::map<std::string, tools::header_list>& headers, const bool full) const
+{
+    Decoder::get_headers(headers, full);
+
+    if (this->type != "ML" && this->type != "CHASE")
+    {
+        auto p = this->get_prefix();
+
+        if (this->tail_length && full)
+            headers[p].push_back(std::make_pair("Tail length", std::to_string(this->tail_length)));
+
+        std::stringstream poly;
+        poly << "{0" << std::oct << this->poly[0] << ",0" << std::oct << this->poly[1] << "}";
+        headers[p].push_back(std::make_pair(std::string("Polynomials"), poly.str()));
+
+        if (this->type == "PLVA") headers[p].push_back(std::make_pair("Num. of lists (L)", std::to_string(this->L)));
+    }
+}
+
+template<typename B, typename Q>
+module::Decoder_SIHO<B, Q>*
+Decoder_conv ::build_viterbi(const std::vector<std::vector<int>>& trellis) const
+{
+    return new module::Decoder_Viterbi_SIHO<B, Q>(this->K, trellis, true);
+}
+
+template<typename B, typename Q>
+module::Decoder_SIHO<B, Q>*
+Decoder_conv ::build_viterbi_list(const std::vector<std::vector<int>>& trellis, const module::CRC<B>* crc) const
+{
+    return new module::Decoder_Viterbi_list_parallel<B, Q>(this->K, this->N_cw, this->L, *crc, trellis, true);
+}
+
+template<typename B, typename Q>
+module::Decoder_SIHO<B, Q>*
+Decoder_conv ::build(const std::vector<std::vector<int>>& trellis,
+                     const module::CRC<B>* crc,
+                     module::Encoder<B>* encoder) const
+{
+    try
+    {
+        return Decoder::build<B, Q>(encoder);
+    }
+    catch (spu::tools::cannot_allocate const&)
+    {
+        if (this->type == "VITERBI") return build_viterbi<B, Q>(trellis);
+        if (this->type == "PLVA" && crc != nullptr) return build_viterbi_list<B, Q>(trellis, crc);
+    }
+
+    throw spu::tools::cannot_allocate(__FILE__, __LINE__, __func__);
+}
+
+// ==================================================================================== explicit template instantiation
+#include "Tools/types.h"
+#ifdef AFF3CT_MULTI_PREC
+template aff3ct::module::Decoder_SIHO<B_8, Q_8>*
+aff3ct::factory::Decoder_conv::build<B_8, Q_8>(const std::vector<std::vector<int>>&,
+                                               const module::CRC<B_8>*,
+                                               module::Encoder<B_8>*) const;
+template aff3ct::module::Decoder_SIHO<B_16, Q_16>*
+aff3ct::factory::Decoder_conv::build<B_16, Q_16>(const std::vector<std::vector<int>>&,
+                                                 const module::CRC<B_16>*,
+                                                 module::Encoder<B_16>*) const;
+template aff3ct::module::Decoder_SIHO<B_32, Q_32>*
+aff3ct::factory::Decoder_conv::build<B_32, Q_32>(const std::vector<std::vector<int>>&,
+                                                 const module::CRC<B_32>*,
+                                                 module::Encoder<B_32>*) const;
+template aff3ct::module::Decoder_SIHO<B_64, Q_64>*
+aff3ct::factory::Decoder_conv::build<B_64, Q_64>(const std::vector<std::vector<int>>&,
+                                                 const module::CRC<B_64>*,
+                                                 module::Encoder<B_64>*) const;
+#else
+template aff3ct::module::Decoder_SIHO<B, Q>*
+aff3ct::factory::Decoder_conv::build<B, Q>(const std::vector<std::vector<int>>&,
+                                           const module::CRC<B>*,
+                                           module::Encoder<B>*) const;
+#endif
+// ==================================================================================== explicit template instantiation

--- a/src/Factory/Module/Encoder/Conv/Encoder_conv.cpp
+++ b/src/Factory/Module/Encoder/Conv/Encoder_conv.cpp
@@ -1,0 +1,107 @@
+#include <cmath>
+#include <cstdio>
+#include <ios>
+#include <sstream>
+#include <streampu.hpp>
+#include <utility>
+
+#include "Factory/Module/Encoder/Conv/Encoder_conv.hpp"
+#include "Tools/Documentation/documentation.h"
+
+using namespace aff3ct;
+using namespace aff3ct::factory;
+
+const std::string aff3ct::factory::Encoder_conv_name = "Encoder CONV";
+const std::string aff3ct::factory::Encoder_conv_prefix = "enc";
+
+Encoder_conv ::Encoder_conv(const std::string& prefix)
+  : Encoder(Encoder_conv_name, prefix)
+{
+    this->type = "CONV";
+    this->systematic = false;
+}
+
+Encoder_conv*
+Encoder_conv ::clone() const
+{
+    return new Encoder_conv(*this);
+}
+
+void
+Encoder_conv ::get_description(cli::Argument_map_info& args) const
+{
+    Encoder::get_description(args);
+
+    auto p = this->get_prefix();
+    const std::string class_name = "factory::Encoder_conv::";
+
+    args.erase({ p + "-cw-size", "N" });
+
+    cli::add_options(args.at({ p + "-type" }), 0, "CONV");
+
+    tools::add_arg(args, p, class_name + "p+poly", cli::Text());
+}
+
+void
+Encoder_conv ::store(const cli::Argument_map_value& vals)
+{
+    Encoder::store(vals);
+
+    auto p = this->get_prefix();
+
+    if (vals.exist({ p + "-poly" }))
+    {
+        auto poly_str = vals.at({ p + "-poly" });
+
+#ifdef _MSC_VER
+        sscanf_s(poly_str.c_str(), "{%o,%o}", &this->poly[0], &this->poly[1]);
+#else
+        std::sscanf(poly_str.c_str(), "{%o,%o}", &this->poly[0], &this->poly[1]);
+#endif
+    }
+
+    const int n_ff = (int)std::floor(std::log2((float)std::max(this->poly[0], this->poly[1])));
+    this->tail_length = 2 * n_ff;
+    this->N_cw = 2 * this->K + this->tail_length;
+    this->R = (float)this->K / (float)this->N_cw;
+}
+
+void
+Encoder_conv ::get_headers(std::map<std::string, tools::header_list>& headers, const bool full) const
+{
+    Encoder::get_headers(headers, full);
+
+    auto p = this->get_prefix();
+
+    if (this->tail_length) headers[p].push_back(std::make_pair("Tail length", std::to_string(this->tail_length)));
+
+    std::stringstream poly;
+    poly << "{0" << std::oct << this->poly[0] << ",0" << std::oct << this->poly[1] << "}";
+    headers[p].push_back(std::make_pair(std::string("Polynomials"), poly.str()));
+}
+
+template<typename B>
+module::Encoder_conv<B>*
+Encoder_conv ::build() const
+{
+    if (this->type == "CONV") return new module::Encoder_conv<B>(this->K, this->N_cw, this->poly);
+
+    throw spu::tools::cannot_allocate(__FILE__, __LINE__, __func__);
+}
+
+// ==================================================================================== explicit template instantiation
+#include "Tools/types.h"
+#ifdef AFF3CT_MULTI_PREC
+template aff3ct::module::Encoder_conv<B_8>*
+aff3ct::factory::Encoder_conv::build<B_8>() const;
+template aff3ct::module::Encoder_conv<B_16>*
+aff3ct::factory::Encoder_conv::build<B_16>() const;
+template aff3ct::module::Encoder_conv<B_32>*
+aff3ct::factory::Encoder_conv::build<B_32>() const;
+template aff3ct::module::Encoder_conv<B_64>*
+aff3ct::factory::Encoder_conv::build<B_64>() const;
+#else
+template aff3ct::module::Encoder_conv<B>*
+aff3ct::factory::Encoder_conv::build<B>() const;
+#endif
+// ==================================================================================== explicit template instantiation

--- a/src/Factory/Tools/Codec/Codec_SIHO.cpp
+++ b/src/Factory/Tools/Codec/Codec_SIHO.cpp
@@ -2,6 +2,7 @@
 
 #include "Factory/Tools/Codec/BCH/Codec_BCH.hpp"
 #include "Factory/Tools/Codec/Codec_SIHO.hpp"
+#include "Factory/Tools/Codec/Conv/Codec_conv.hpp"
 #include "Factory/Tools/Codec/LDPC/Codec_LDPC.hpp"
 #include "Factory/Tools/Codec/Polar/Codec_polar.hpp"
 #include "Factory/Tools/Codec/Polar_MK/Codec_polar_MK.hpp"
@@ -38,6 +39,7 @@ Codec_SIHO ::build(const module::CRC<B>* crc) const
 {
 
     if (get_name() == Codec_BCH_name) return dynamic_cast<const Codec_BCH&>(*this).template build<B, Q>(crc);
+    if (get_name() == Codec_conv_name) return dynamic_cast<const Codec_conv&>(*this).template build<B, Q>(crc);
     if (get_name() == Codec_LDPC_name) return dynamic_cast<const Codec_LDPC&>(*this).template build<B, Q>(crc);
     if (get_name() == Codec_polar_name) return dynamic_cast<const Codec_polar&>(*this).template build<B, Q>(crc);
     if (get_name() == Codec_polar_PAC_name)

--- a/src/Factory/Tools/Codec/Conv/Codec_conv.cpp
+++ b/src/Factory/Tools/Codec/Conv/Codec_conv.cpp
@@ -1,0 +1,93 @@
+#include "Factory/Tools/Codec/Conv/Codec_conv.hpp"
+#include "Factory/Module/Decoder/Conv/Decoder_conv.hpp"
+#include "Factory/Module/Encoder/Conv/Encoder_conv.hpp"
+
+using namespace aff3ct;
+using namespace aff3ct::factory;
+
+const std::string aff3ct::factory::Codec_conv_name = "Codec CONV";
+const std::string aff3ct::factory::Codec_conv_prefix = "cdc";
+
+Codec_conv ::Codec_conv(const std::string& prefix)
+  : Codec_SIHO(Codec_conv_name, prefix)
+{
+    Codec::set_enc(new Encoder_conv("enc"));
+    Codec::set_dec(new Decoder_conv("dec"));
+}
+
+Codec_conv*
+Codec_conv ::clone() const
+{
+    return new Codec_conv(*this);
+}
+
+void
+Codec_conv ::get_description(cli::Argument_map_info& args) const
+{
+    Codec_SIHO::get_description(args);
+
+    enc->get_description(args);
+    dec->get_description(args);
+
+    auto pdec = dec->get_prefix();
+
+    args.erase({ pdec + "-cw-size", "N" });
+    args.erase({ pdec + "-info-bits", "K" });
+    args.erase({ pdec + "-poly" });
+}
+
+void
+Codec_conv ::store(const cli::Argument_map_value& vals)
+{
+    Codec_SIHO::store(vals);
+
+    auto enc_conv = dynamic_cast<Encoder_conv*>(enc.get());
+    auto dec_conv = dynamic_cast<Decoder_conv*>(dec.get());
+
+    enc->store(vals);
+
+    dec_conv->K = enc_conv->K;
+    dec_conv->N_cw = enc_conv->N_cw;
+    dec_conv->poly = enc_conv->poly;
+
+    dec->store(vals);
+
+    K = enc->K;
+    N_cw = enc->N_cw;
+    N = enc->N_cw;
+    tail_length = enc->tail_length;
+}
+
+void
+Codec_conv ::get_headers(std::map<std::string, tools::header_list>& headers, const bool full) const
+{
+    Codec_SIHO::get_headers(headers, full);
+
+    enc->get_headers(headers, full);
+    dec->get_headers(headers, full);
+}
+
+template<typename B, typename Q>
+tools::Codec_conv<B, Q>*
+Codec_conv ::build(const module::CRC<B>* crc) const
+{
+    return new tools::Codec_conv<B, Q>(
+      dynamic_cast<const Encoder_conv&>(*enc), dynamic_cast<const Decoder_conv&>(*dec), crc);
+}
+
+// ==================================================================================== explicit template instantiation
+#include "Tools/types.h"
+#ifdef AFF3CT_MULTI_PREC
+template aff3ct::tools::Codec_conv<B_8, Q_8>*
+aff3ct::factory::Codec_conv::build<B_8, Q_8>(const aff3ct::module::CRC<B_8>*) const;
+template aff3ct::tools::Codec_conv<B_16, Q_16>*
+aff3ct::factory::Codec_conv::build<B_16, Q_16>(const aff3ct::module::CRC<B_16>*) const;
+template aff3ct::tools::Codec_conv<B_32, Q_32>*
+aff3ct::factory::Codec_conv::build<B_32, Q_32>(const aff3ct::module::CRC<B_32>*) const;
+template aff3ct::tools::Codec_conv<B_64, Q_64>*
+aff3ct::factory::Codec_conv::build<B_64, Q_64>(const aff3ct::module::CRC<B_64>*) const;
+#else
+template aff3ct::tools::Codec_conv<B, Q>*
+aff3ct::factory::Codec_conv::build<B, Q>(const aff3ct::module::CRC<B>*) const;
+#endif
+// ==================================================================================== explicit template instantiation

--- a/src/Launcher/Code/Conv/Conv.cpp
+++ b/src/Launcher/Code/Conv/Conv.cpp
@@ -1,0 +1,49 @@
+#include "Launcher/Code/Conv/Conv.hpp"
+#include "Launcher/Simulation/BFER_std.hpp"
+
+using namespace aff3ct;
+using namespace aff3ct::launcher;
+
+template<class L, typename B, typename R, typename Q>
+Conv<L, B, R, Q>::Conv(const int argc, const char** argv, std::ostream& stream)
+  : L(argc, argv, stream)
+  , params_cdc(new factory::Codec_conv("cdc"))
+{
+    this->params.set_cdc(params_cdc);
+}
+
+template<class L, typename B, typename R, typename Q>
+void
+Conv<L, B, R, Q>::get_description_args()
+{
+    params_cdc->get_description(this->args);
+
+    auto penc = params_cdc->enc->get_prefix();
+
+    this->args.erase({ penc + "-fra", "F" });
+    this->args.erase({ penc + "-seed", "S" });
+
+    L::get_description_args();
+}
+
+template<class L, typename B, typename R, typename Q>
+void
+Conv<L, B, R, Q>::store_args()
+{
+    params_cdc->store(this->arg_vals);
+
+    L::store_args();
+}
+
+// ==================================================================================== explicit template instantiation
+#include "Launcher/Simulation/BFER_std.hpp"
+#include "Tools/types.h"
+#ifdef AFF3CT_MULTI_PREC
+template class aff3ct::launcher::Conv<aff3ct::launcher::BFER_std<B_8, R_8, Q_8>, B_8, R_8, Q_8>;
+template class aff3ct::launcher::Conv<aff3ct::launcher::BFER_std<B_16, R_16, Q_16>, B_16, R_16, Q_16>;
+template class aff3ct::launcher::Conv<aff3ct::launcher::BFER_std<B_32, R_32, Q_32>, B_32, R_32, Q_32>;
+template class aff3ct::launcher::Conv<aff3ct::launcher::BFER_std<B_64, R_64, Q_64>, B_64, R_64, Q_64>;
+#else
+template class aff3ct::launcher::Conv<aff3ct::launcher::BFER_std<B, R, Q>, B, R, Q>;
+#endif
+// ==================================================================================== explicit template instantiation

--- a/src/Launcher/Code/Conv/Conv.hpp
+++ b/src/Launcher/Code/Conv/Conv.hpp
@@ -1,0 +1,29 @@
+#ifndef LAUNCHER_CONV_HPP_
+#define LAUNCHER_CONV_HPP_
+
+#include <iostream>
+
+#include "Factory/Tools/Codec/Conv/Codec_conv.hpp"
+
+namespace aff3ct
+{
+namespace launcher
+{
+template<class L, typename B = int, typename R = float, typename Q = R>
+class Conv : public L
+{
+  protected:
+    factory::Codec_conv* params_cdc;
+
+  public:
+    Conv(const int argc, const char** argv, std::ostream& stream = std::cout);
+    virtual ~Conv() = default;
+
+  protected:
+    virtual void get_description_args();
+    virtual void store_args();
+};
+}
+}
+
+#endif /* LAUNCHER_CONV_HPP_ */

--- a/src/Module/Encoder/Conv/Encoder_conv.cpp
+++ b/src/Module/Encoder/Conv/Encoder_conv.cpp
@@ -19,6 +19,8 @@ Encoder_conv<B>::Encoder_conv(const int K, const int N, const std::vector<int>& 
 {
     const std::string name = "Encoder_conv";
     this->set_name(name);
+    for (auto& t : this->tasks)
+        t->set_replicability(true);
 
     if (n_poly < 2)
     {
@@ -65,6 +67,15 @@ Encoder_conv<B>::Encoder_conv(const int K, const int N, const std::vector<int>& 
         this->info_bits_pos[k] = n_poly * k;
 
     build_tables();
+}
+
+template<typename B>
+Encoder_conv<B>*
+Encoder_conv<B>::clone() const
+{
+    auto m = new Encoder_conv(*this);
+    m->deep_copy(*this);
+    return m;
 }
 
 template<typename B>

--- a/src/Tools/Codec/Conv/Codec_conv.cpp
+++ b/src/Tools/Codec/Conv/Codec_conv.cpp
@@ -1,0 +1,89 @@
+#include <memory>
+#include <sstream>
+#include <streampu.hpp>
+
+#include "Factory/Module/Encoder/Encoder.hpp"
+#include "Factory/Module/Puncturer/Puncturer.hpp"
+#include "Tools/Codec/Conv/Codec_conv.hpp"
+
+using namespace aff3ct;
+using namespace aff3ct::tools;
+
+template<typename B, typename Q>
+Codec_conv<B, Q>::Codec_conv(const factory::Encoder_conv& enc_params,
+                             const factory::Decoder_conv& dec_params,
+                             const module::CRC<B>* crc)
+  : Codec_SIHO<B, Q>(enc_params.K, enc_params.N_cw, enc_params.N_cw)
+  , trellis(new std::vector<std::vector<int>>())
+{
+    // ----------------------------------------------------------------------------------------------------- exceptions
+    if (enc_params.K != dec_params.K)
+    {
+        std::stringstream message;
+        message << "'enc_params.K' has to be equal to 'dec_params.K' ('enc_params.K' = " << enc_params.K
+                << ", 'dec_params.K' = " << dec_params.K << ").";
+        throw spu::tools::invalid_argument(__FILE__, __LINE__, __func__, message.str());
+    }
+
+    if (enc_params.N_cw != dec_params.N_cw)
+    {
+        std::stringstream message;
+        message << "'enc_params.N_cw' has to be equal to 'dec_params.N_cw' ('enc_params.N_cw' = " << enc_params.N_cw
+                << ", 'dec_params.N_cw' = " << dec_params.N_cw << ").";
+        throw spu::tools::invalid_argument(__FILE__, __LINE__, __func__, message.str());
+    }
+
+    // ---------------------------------------------------------------------------------------------------------- tools
+    auto enc_cpy = enc_params;
+    enc_cpy.type = "CONV";
+
+    std::unique_ptr<module::Encoder_conv<B>> encoder_conv(enc_cpy.build<B>());
+    *trellis = encoder_conv->get_trellis();
+
+    // ---------------------------------------------------------------------------------------------------- allocations
+    factory::Puncturer pct_params;
+    pct_params.type = "NO";
+    pct_params.K = enc_params.K;
+    pct_params.N = enc_params.N_cw;
+    pct_params.N_cw = enc_params.N_cw;
+
+    this->set_puncturer(pct_params.build<B, Q>());
+    try
+    {
+        this->set_encoder(enc_params.build<B>());
+    }
+    catch (spu::tools::cannot_allocate const&)
+    {
+        this->set_encoder(static_cast<const factory::Encoder*>(&enc_params)->build<B>());
+    }
+
+    this->set_decoder_siho(dec_params.build<B, Q>(*trellis, crc, &this->get_encoder()));
+}
+
+template<typename B, typename Q>
+Codec_conv<B, Q>*
+Codec_conv<B, Q>::clone() const
+{
+    auto t = new Codec_conv(*this);
+    t->deep_copy(*this);
+    return t;
+}
+
+template<typename B, typename Q>
+const std::vector<std::vector<int>>&
+Codec_conv<B, Q>::get_trellis() const
+{
+    return *this->trellis;
+}
+
+// ==================================================================================== explicit template instantiation
+#include "Tools/types.h"
+#ifdef AFF3CT_MULTI_PREC
+template class aff3ct::tools::Codec_conv<B_8, Q_8>;
+template class aff3ct::tools::Codec_conv<B_16, Q_16>;
+template class aff3ct::tools::Codec_conv<B_32, Q_32>;
+template class aff3ct::tools::Codec_conv<B_64, Q_64>;
+#else
+template class aff3ct::tools::Codec_conv<B, Q>;
+#endif
+// ==================================================================================== explicit template instantiation


### PR DESCRIPTION
## Summary

Addresses the release blocker from #221: wires the feedforward `Encoder_conv` from #218 into the `BFER_std` simulator, the documentation, and the CLI so the new code family is accessible via `-C CONV`.

### Simulator
- `factory::Encoder_conv` + `factory::Decoder_conv` (supporting `VITERBI` and `PLVA`)
- `tools::Codec_conv` + `factory::Codec_conv`
- `launcher::Conv` wired into `BFER_std`
- `CONV` added to `--sim-cde-type`, the `Factory/Launcher` dispatch, the `Codec_SIHO` dispatch, and `aff3ct.hpp`

### Fixes in `module::Encoder_conv` needed for runtime integration
- Added `clone()` method and `set_replicability(true)` on tasks. Without these the runtime refuses to replicate the encoder for the parallel task sequence and the simulator throws at startup (discovered while adding the first `-C CONV` run).

### Documentation
- New `doc/source/user/simulation/parameters/codec/conv/{codec,encoder,decoder}.rst` plus `references.bib`
- `CONV` row in the `--sim-cde-type` table and entry in the codec toctree
- `factory::Encoder_conv::p+poly` and `factory::Decoder_conv::p+{poly,lists,L}` strings in `doc/strings.rst`
- `|CONV|` abbreviation added in `doc/source/conf.py`
- `ci/check-documentation.py` reports zero undocumented or orphaned CONV keys

### Regression references
A companion PR against `aff3ct/error_rate_references` adds:
- `refs/CONV/AWGN/BPSK/Viterbi/CONV_N140_K64_Viterbi_p32.txt` (0-5 dB Eb/N0, e=500)
- `refs/CONV/AWGN/BPSK/Viterbi_list/CONV_N140_K32_L16_Viterbi_p32.txt` (PLVA L=16 with CRC32-GZIP, 0-4 dB Eb/N0, e=500)

## Test plan
- [x] Local build clean (`cmake --build . -j 4`)
- [x] `-C CONV --dec-type VITERBI -K 64`: clean BER waterfall (FER 0.66 → 3e-05 over 0-5 dB Eb/N0)
- [x] `-C CONV --dec-type PLVA --crc-type 32-GZIP --dec-lists 16 -K 64`: runs cleanly
- [x] `ci/check-documentation.py`: zero undocumented/orphaned keys
- [x] `ci/test-regression.py` against the new CONV refs: 2/2 passed

---

Closes #221 for the simulator/docs portion. The submodule bump for the new references will follow once the companion PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)